### PR TITLE
Use slate color palette for minimal design

### DIFF
--- a/app/(site)/blog/page.tsx
+++ b/app/(site)/blog/page.tsx
@@ -15,7 +15,7 @@ export default function BlogPage() {
         <ul className="space-y-4">
           {posts.map((p) => (
             <li key={p.slug}>
-              <Link className="text-plum-400 hover:underline" href={`/blog/${p.slug}`}>
+              <Link className="text-slate-400 hover:underline" href={`/blog/${p.slug}`}>
                 {p.title}
               </Link>
             </li>

--- a/app/(site)/contact/page.tsx
+++ b/app/(site)/contact/page.tsx
@@ -45,7 +45,7 @@ export default function ContactPage() {
           <Button type="submit">Send</Button>
         </form>
         {status === 'sent' && (
-          <p className="text-sm text-plum-400">Message sent!</p>
+          <p className="text-sm text-slate-400">Message sent!</p>
         )}
         {status === 'error' && (
           <p className="text-sm text-red-500">

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -24,13 +24,13 @@ export default function HomePage() {
           </div>
           <div className="flex justify-center gap-6 pt-4">
             <Link href={`mailto:${site.social.email}`} aria-label="Email">
-              <Mail className="h-5 w-5 text-gray-400 hover:text-plum-400" />
+              <Mail className="h-5 w-5 text-gray-400 hover:text-slate-400" />
             </Link>
             <Link href={site.social.github} aria-label="GitHub">
-              <Github className="h-5 w-5 text-gray-400 hover:text-plum-400" />
+              <Github className="h-5 w-5 text-gray-400 hover:text-slate-400" />
             </Link>
             <Link href={site.social.linkedin} aria-label="LinkedIn">
-              <Linkedin className="h-5 w-5 text-gray-400 hover:text-plum-400" />
+              <Linkedin className="h-5 w-5 text-gray-400 hover:text-slate-400" />
             </Link>
           </div>
         </Container>
@@ -40,7 +40,7 @@ export default function HomePage() {
           <ul className="flex flex-col gap-2 text-sm sm:flex-row sm:justify-center sm:gap-6">
             {site.highlights.map((h) => (
               <li key={h} className="flex items-center gap-2">
-                <span className="h-1 w-1 rounded-full bg-plum-500" />
+                <span className="h-1 w-1 rounded-full bg-slate-500" />
                 {h}
               </li>
             ))}

--- a/app/(site)/projects/page.tsx
+++ b/app/(site)/projects/page.tsx
@@ -17,7 +17,7 @@ export default function ProjectsPage() {
         <div className="flex flex-wrap gap-2">
           <Badge
             onClick={() => setFilter(null)}
-            className={filter === null ? 'bg-plum-600 text-white' : 'cursor-pointer'}
+            className={filter === null ? 'bg-slate-600 text-white' : 'cursor-pointer'}
           >
             All
           </Badge>
@@ -25,7 +25,7 @@ export default function ProjectsPage() {
             <Badge
               key={t}
               onClick={() => setFilter(t === filter ? null : t)}
-              className={filter === t ? 'bg-plum-600 text-white' : 'cursor-pointer'}
+              className={filter === t ? 'bg-slate-600 text-white' : 'cursor-pointer'}
             >
               {t}
             </Badge>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -17,8 +17,8 @@ export default function Header() {
               key={item.href}
               href={item.href}
               className={cn(
-                'text-sm transition-colors hover:text-plum-400',
-                pathname === item.href ? 'text-plum-400' : 'text-foreground'
+                'text-sm transition-colors hover:text-slate-400',
+                pathname === item.href ? 'text-slate-400' : 'text-foreground'
               )}
             >
               {item.name}

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -7,7 +7,7 @@ const badgeVariants = cva(
   {
     variants: {
       variant: {
-        default: 'border-transparent bg-plum-700 text-white',
+        default: 'border-transparent bg-slate-700 text-white',
         outline: 'border-gray-700 text-foreground',
       },
     },

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -5,11 +5,11 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-plum-500 focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none ring-offset-background',
+  'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none ring-offset-background',
   {
     variants: {
       variant: {
-        default: 'bg-plum-700 text-white hover:bg-plum-600',
+        default: 'bg-slate-700 text-white hover:bg-slate-600',
         secondary: 'bg-gray-700 text-white hover:bg-gray-600',
         outline: 'border border-gray-700 hover:bg-gray-700',
         ghost: 'hover:bg-gray-700',

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -4,9 +4,9 @@
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
+    --background: 0 0% 98%;
     --foreground: 222.2 47.4% 11.2%;
-    --card: 0 0% 100%;
+    --card: 0 0% 98%;
     --card-foreground: 222.2 47.4% 11.2%;
     --border: 214.3 31.8% 91.4%;
     --ring: 215 20.2% 65.1%;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -7,19 +7,6 @@ const config: Config = {
   theme: {
     extend: {
       colors: {
-        plum: {
-          50: '#f7f4f7',
-          100: '#ede4ea',
-          200: '#dcc7d8',
-          300: '#c2a2ba',
-          400: '#a87d9c',
-          500: '#8d587e',
-          600: '#734260',
-          700: '#522f4d',
-          800: '#41253d',
-          900: '#2d192a',
-          950: '#180c16',
-        },
         background: 'hsl(var(--background))',
         foreground: 'hsl(var(--foreground))',
         card: 'hsl(var(--card))',


### PR DESCRIPTION
## Summary
- adopt a neutral slate palette across UI components
- soften page background and card colors for a cleaner look

## Testing
- `npm run lint`
- `npm test` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab566179088326a8ce9b1f2295e499