### PR TITLE
fix: apply theme tokens for light/dark toggle

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -3,8 +3,8 @@ import { site } from '@/data/site';
 
 export default function Footer() {
   return (
-    <footer className="mt-12 border-t border-white/10 bg-black/20 backdrop-blur py-6">
-      <Container className="text-center text-sm text-gray-400">
+    <footer className="mt-12 border-t border-border/40 bg-background/60 backdrop-blur py-6">
+      <Container className="text-center text-sm text-foreground/60">
         © {new Date().getFullYear()} {site.name}
       </Container>
     </footer>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -9,7 +9,7 @@ import { cn } from '@/lib/utils';
 export default function Header() {
   const pathname = usePathname();
   return (
-    <header className="fixed top-0 z-40 w-full border-b border-white/10 bg-black/40 backdrop-blur">
+    <header className="fixed top-0 z-40 w-full border-b border-border/40 bg-background/60 backdrop-blur">
       <Container className="flex h-14 items-center justify-between">
         <nav className="flex items-center gap-6">
           {site.nav.map((item) => (
@@ -17,8 +17,10 @@ export default function Header() {
               key={item.href}
               href={item.href}
               className={cn(
-                'text-sm font-medium transition-colors hover:text-indigo-400',
-                pathname === item.href ? 'text-indigo-400' : 'text-gray-200'
+                'text-sm font-medium transition-colors hover:text-indigo-600 dark:hover:text-indigo-400',
+                pathname === item.href
+                  ? 'text-indigo-600 dark:text-indigo-400'
+                  : 'text-foreground'
               )}
             >
               {item.name}

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -5,7 +5,7 @@ export const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDi
   ({ className, ...props }, ref) => (
     <div
       ref={ref}
-      className={cn('rounded-lg border border-white/10 bg-white/5 backdrop-blur-sm text-card-foreground shadow-sm', className)}
+      className={cn('rounded-lg border border-border bg-card backdrop-blur-sm text-card-foreground shadow-sm', className)}
       {...props}
     />
   )

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -20,6 +20,6 @@
     --ring: 262 83% 58%;
   }
   body {
-    @apply min-h-screen bg-gradient-to-br from-gray-900 via-indigo-900 to-black text-foreground antialiased font-sans;
+    @apply min-h-screen bg-background text-foreground antialiased font-sans;
   }
 }


### PR DESCRIPTION
## Summary
- use theme variables for body background to respect light/dark mode
- update header, footer, and card styles to utilize theme tokens

## Testing
- `npm test` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab64d419e48326bab68dc785f22c5b